### PR TITLE
Add secret key hash on produce/consume

### DIFF
--- a/demo/vendorA/main.go
+++ b/demo/vendorA/main.go
@@ -8,11 +8,12 @@ import (
 
 // An example vendor A's backend, showing how easy it is to produce data to Supertype
 func main() {
-	temperature := "153"
-	attribute := "temperature"
+	temperature := "200"
+	attribute := "caloriesBurned"
 	supertypeID := "user123"
 
-	err := goimplement.Produce(temperature, attribute, supertypeID, "91032863405535923859153039920779555024328120618368196021389762057833204795281", "04fcee14eaa83337315688ef3db63586ecceddfddf436b57444958806b566ec9d1e809577c44fcceeac9beb9d7be82f5b9be84d94f8bc54a82cf1a6f3c9ae37140")
+	// this is the wrong sk for the given pk
+	err := goimplement.Produce(temperature, attribute, supertypeID, "91032863405535923859153039920779555024328120618368196021389762057833204795281", "042e26494ef3eea3622d5bd7ba602e06476f4bde3f0418d2cb24c7d04fa7b6985105f2782cbc5a0bf7ac20911f7c7e307a9c77ce7ceef6e0cb45d4c996fc63a559")
 	if err != nil {
 		fmt.Printf("err: %v\n", err)
 	}

--- a/goImplement/decryption.go
+++ b/goImplement/decryption.go
@@ -48,14 +48,8 @@ func LocalDecrypt(aPriKey *ecdsa.PrivateKey, capsule *Capsule, cipherText []byte
 
 func decryptKeyGen(bPriKey *ecdsa.PrivateKey, capsule *Capsule, pubX *ecdsa.PublicKey) ([]byte, error) {
 	S := PointScalarMul(pubX, bPriKey.D)
-	d := HashToCurve(
-		ConcatBytes(
-			ConcatBytes(
-				PointToBytes(pubX),
-				PointToBytes(&bPriKey.PublicKey)),
-			PointToBytes(S)))
-	point := PointScalarMul(
-		PointScalarAdd(capsule.E, capsule.V), d)
+	d := HashToCurve(ConcatBytes(ConcatBytes(PointToBytes(pubX), PointToBytes(&bPriKey.PublicKey)), PointToBytes(S)))
+	point := PointScalarMul(PointScalarAdd(capsule.E, capsule.V), d)
 	keyBytes, err := Sha3Hash(PointToBytes(point))
 	if err != nil {
 		return nil, err

--- a/goImplement/encryption.go
+++ b/goImplement/encryption.go
@@ -26,8 +26,8 @@ func GCMEncrypt(plaintext []byte, key string, iv []byte, additionalData []byte) 
 }
 
 // Encrypt creates the AES key, encrypts it it with GCM, and returns ciphertext and capsule
-func Encrypt(message string, pubKey *ecdsa.PublicKey) (cipherText []byte, capsule *Capsule, err error) {
-	capsule, aesKeyBytes, err := EncryptKeyGen(pubKey)
+func Encrypt(message string, pk *ecdsa.PublicKey) (cipherText []byte, capsule *Capsule, err error) {
+	capsule, aesKeyBytes, err := EncryptKeyGen(pk)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -42,7 +42,7 @@ func Encrypt(message string, pubKey *ecdsa.PublicKey) (cipherText []byte, capsul
 }
 
 // EncryptKeyGen generates the capsule and AES key
-func EncryptKeyGen(pubKey *ecdsa.PublicKey) (*Capsule, []byte, error) {
+func EncryptKeyGen(pk *ecdsa.PublicKey) (*Capsule, []byte, error) {
 	s := new(big.Int)
 	skE, pkE, err := GenerateKeys()
 	skV, pkV, err := GenerateKeys()
@@ -55,7 +55,7 @@ func EncryptKeyGen(pubKey *ecdsa.PublicKey) (*Capsule, []byte, error) {
 			PointToBytes(pkE),
 			PointToBytes(pkV)))
 	s = AddBigInteger(skV.D, MultiplyBigInteger(skV.D, h))
-	point := PointScalarMul(pubKey, AddBigInteger(skE.D, skV.D))
+	point := PointScalarMul(pk, AddBigInteger(skE.D, skV.D))
 
 	aesKeyBytes, err := Sha3Hash(PointToBytes(point))
 	if err != nil {

--- a/goImplement/keys.go
+++ b/goImplement/keys.go
@@ -46,9 +46,9 @@ func PrivateKeyToString(privateKey *ecdsa.PrivateKey) string {
 }
 
 // PublicKeyToString encodes an ECDSA public key to a string
-func PublicKeyToString(publicKey *ecdsa.PublicKey) string {
-	pubKeyBytes := PointToBytes(publicKey)
-	return hex.EncodeToString(pubKeyBytes)
+func PublicKeyToString(pk *ecdsa.PublicKey) string {
+	pkBytes := PointToBytes(pk)
+	return hex.EncodeToString(pkBytes)
 }
 
 // GenerateKeys generates a <private,public> key pair

--- a/goImplement/model.go
+++ b/goImplement/model.go
@@ -21,6 +21,7 @@ type ObservationRequest struct {
 	CapsuleS    string `json:"capsuleS"`
 	SupertypeID string `json:"supertypeID"`
 	PublicKey   string `json:"pk"`
+	SkHash      string `json:"skHash"`
 }
 
 // ObservationResponse is returned from the server

--- a/goImplement/reencryption.go
+++ b/goImplement/reencryption.go
@@ -12,7 +12,7 @@ func ReEncrypt(rk *big.Int, capsule *Capsule) (*Capsule, error) {
 	tempX, tempY := CURVE.ScalarMult(capsule.E.X, capsule.E.Y, HashToCurve(ConcatBytes(PointToBytes(capsule.E), PointToBytes(capsule.V))).Bytes())
 	x2, y2 := CURVE.Add(capsule.V.X, capsule.V.Y, tempX, tempY)
 	if x1.Cmp(x2) != 0 || y1.Cmp(y2) != 0 {
-		return nil, fmt.Errorf("%s", "Capsule not match")
+		return nil, fmt.Errorf("%s", "Capsule does not match.")
 	}
 
 	newCapsule := &Capsule{
@@ -48,20 +48,15 @@ func CreateReencryptionKeys(vendor string, sk *ecdsa.PrivateKey) (*[2]string, er
 }
 
 // ReKeyGen generates a re-encryption key and sends it to Server
-func ReKeyGen(aPriKey *ecdsa.PrivateKey, bPubKey *ecdsa.PublicKey) (*big.Int, *ecdsa.PublicKey, error) {
+func ReKeyGen(skA *ecdsa.PrivateKey, pkB *ecdsa.PublicKey) (*big.Int, *ecdsa.PublicKey, error) {
 	priX, pubX, err := GenerateKeys()
 	if err != nil {
 		return nil, nil, err
 	}
 
-	point := PointScalarMul(bPubKey, priX.D)
-	d := HashToCurve(
-		ConcatBytes(
-			ConcatBytes(
-				PointToBytes(pubX),
-				PointToBytes(bPubKey)),
-			PointToBytes(point)))
-	rk := MultiplyBigInteger(aPriKey.D, GetInverse(d))
+	point := PointScalarMul(pkB, priX.D)
+	d := HashToCurve(ConcatBytes(ConcatBytes(PointToBytes(pubX), PointToBytes(pkB)), PointToBytes(point)))
+	rk := MultiplyBigInteger(skA.D, GetInverse(d))
 	rk.Mod(rk, N)
 
 	return rk, pubX, nil

--- a/goImplement/utils.go
+++ b/goImplement/utils.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
+	"crypto/sha256"
+	"encoding/hex"
 	"math/big"
 
 	"golang.org/x/crypto/sha3"
@@ -91,4 +93,11 @@ func Contains(s []string, e string) bool {
 func GetInverse(a *big.Int) (res *big.Int) {
 	res = new(big.Int).ModInverse(a, N)
 	return
+}
+
+// GetSecretKeyHash returns the hashed value of the secret key
+func GetSecretKeyHash(skVendor string) string {
+	h := sha256.New()
+	h.Write([]byte(skVendor))
+	return hex.EncodeToString(h.Sum(nil))
 }


### PR DESCRIPTION
* Creates a `skHash` on both produce and consume, so that the server can verify that the request is coming from a verified vendor