### PR TITLE
Remove hashing of API Key. We do that in the supertype server

### DIFF
--- a/goImplement/goImplement.go
+++ b/goImplement/goImplement.go
@@ -18,9 +18,6 @@ You need only encrypt once to send data anywhere within the ecosystem
 @param userKey the user's unique AES encryption key
 */
 func Produce(data string, attribute string, supertypeID string, apiKey string, userKey string) error {
-	// Generate hash of API key to be used as a signing measure for producing/consuming data
-	apiKeyHash := GetAPIKeyHash(apiKey)
-
 	// Encrypt data using basic AES encryption
 	ciphertext, iv, err := Encrypt(data, userKey)
 	if err != nil {
@@ -47,7 +44,7 @@ func Produce(data string, attribute string, supertypeID string, apiKey string, u
 		return err
 	}
 	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("X-API-Key", apiKeyHash)
+	req.Header.Add("X-API-Key", apiKey)
 	resp, err := client.Do(req)
 	if err != nil {
 		fmt.Println(err)
@@ -69,9 +66,6 @@ This data is source-agnostic, and encrypted end-to-end
 @return plaintext the decrypted observation the vendor is requesting
 */
 func Consume(attribute string, supertypeID string, apiKey string, userKey string) (plaintext *[]string, err error) {
-	// Generate hash of API key to be used as a signing measure for producing/consuming data
-	apiKeyHash := GetAPIKeyHash(apiKey)
-
 	requestBody, err := json.Marshal(map[string]string{
 		"attribute":   attribute,
 		"supertypeID": supertypeID,
@@ -86,7 +80,7 @@ func Consume(attribute string, supertypeID string, apiKey string, userKey string
 		return nil, err
 	}
 	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("X-API-Key", apiKeyHash)
+	req.Header.Add("X-API-Key", apiKey)
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err

--- a/goImplement/utils.go
+++ b/goImplement/utils.go
@@ -4,9 +4,7 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/base64"
-	"encoding/hex"
 	"io"
 	"strings"
 )
@@ -70,11 +68,4 @@ func Decrypt(ciphertext string, userKey string) (*string, *string, error) {
 	res := string(plaintext)
 
 	return &res, &attribute, nil
-}
-
-// GetAPIKeyHash returns the hashed value of the secret key
-func GetAPIKeyHash(skVendor string) string {
-	h := sha256.New()
-	h.Write([]byte(skVendor))
-	return hex.EncodeToString(h.Sum(nil))
 }


### PR DESCRIPTION
* Removing API Key hashing from client library

This shouldn't have been exposed to customers in the first place. This is an internal measure we use in order to keep our customers' keys secure (we only store hashes of keys, not the keys themself). Requiring the customer to hash both
1. Introduces complexity
2. Prevents us from hashing internally for other authorized functionality outside of produce/consume